### PR TITLE
Add {pdf,lua,xe}latex 

### DIFF
--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -99,15 +99,17 @@
     (goto-char (point-max))
     (cond
       ((re-search-backward (format "^%s finished at" name) nil t)
-       (re-search-backward "^Run number [0-9]+ of rule '\\(pdf\\|lua\\|xe\\)?latex'" nil t)
-       (forward-line 5)
-       (let ((beg (point)))
-         (re-search-forward "^Latexmk:" nil t)
-         (beginning-of-line)
-         (save-restriction
-           (narrow-to-region beg (point))
-           (goto-char (point-min))
-           (TeX-LaTeX-sentinel process name))))
+       (if (re-search-backward "^Run number [0-9]+ of rule '\\(pdf\\|lua\\|xe\\)?latex'" nil t)
+           (progn
+             (forward-line 5)
+             (let ((beg (point)))
+               (re-search-forward "^Latexmk:" nil t)
+               (beginning-of-line)
+               (save-restriction
+                 (narrow-to-region beg (point))
+                 (goto-char (point-min))
+                 (TeX-LaTeX-sentinel process name))))
+         (message (format "%s: nothing to do" name))))
       ((re-search-backward (format "^%s exited abnormally with code" name) nil t)
        (re-search-backward "^Collected error summary (may duplicate other messages):" nil t)
        (re-search-forward "^  \\([^:]+\\):" nil t)


### PR DESCRIPTION
These changes improve the regex to match pdflatex and fixes an incorrect error shown if there was nothing to do.
