### PR TITLE
Fix sentinel regexes

### DIFF
--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -99,7 +99,7 @@
     (goto-char (point-max))
     (cond
       ((re-search-backward (format "^%s finished at" mode-name) nil t)
-       (if (re-search-backward "^Latexmk: Run number [0-9]+ of rule '\\(pdf\\|lua\\|xe\\)?latex'" nil t)
+       (if (re-search-backward "^Run number [0-9]+ of rule '\\(pdf\\|lua\\|xe\\)?latex'" nil t)
            (progn
              (forward-line 5)
              (let ((beg (point)))


### PR DESCRIPTION
I do not know when LatexMk and AUCTeX changed, but the existing sentinel regexes do not work. The changes are:
- **'name' becomes 'mode-name'**: TeX-synchronous-sentinel in TeX-run-TeX uses 'mode-name' for the post-mortem tag instead of 'name'
- **'^Run number...' is prefixed with 'Latexmk: '**: That is how the output is setup in my run using TeXLive 2013
