### PR TITLE
pass more options to latexmk

### DIFF
--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -87,7 +87,7 @@
   "Add LatexMk command to TeX-command-list."
   (setq-default TeX-command-list
                 (cons
-                 '("LatexMk" "latexmk %t" TeX-run-latexmk nil
+                 '("LatexMk" "latexmk %S%(mode) %t" TeX-run-latexmk nil
                    (plain-tex-mode latex-mode doctex-mode) :help "Run LatexMk")
                  TeX-command-list)
                 LaTeX-clean-intermediate-suffixes


### PR DESCRIPTION
I need `%S` to take advantage of `TeX-source-correlate-mode` / SyncTeX and I guess `%(mode)` does not hurt either.
