### PR TITLE
support toggling pdf mode inside emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,31 @@ To use this package, add the following line to your `.emacs` file:
     (require 'auctex-latexmk)
     (auctex-latexmk-setup)
 ```
-And add the following line to your `.latexmkrc` file:
-```perl
-    # .latexmkrc starts
-    $pdf_mode = 1;
-    # .latexmkrc ends
-```
 After that, by using `M-x TeX-command-master` (or C-c C-c), you can use
 LatexMk command to compile TeX source.
+    
+LatexMk will inherit many AUCTeX settings, including:
+* Run with `-interaction-nonestopmode` if `TeX-interactive-mode` minor mode is
+  active
+* Run with `-synctex` if `TeX-source-correlate-mode` is active
+  
+If you would like LatexMk to aso pass the `-pdf` flag when `TeX-PDF-mode` is
+active add
+```elisp
+    (setq auctex-latexmk-inherit-TeX-PDF-mode t)
+```
+to your `.emacs` file.
+
+Additional configuration of `latexmk` is possible by creating a `~/.latexmkrc` file. For
+example, to always compile to pdf add the following line to your `.latexmkrc`
+file:
+```perl
+# .latexmkrc starts
+$pdf_mode = 1;
+# .latexmkrc ends
+```
+Additional documention describing all the available options is available on
+[CTAN](http://ctan.org/pkg/latexmk).
 
 For Japanese users:
 

--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -74,6 +74,10 @@
   "Encoding mapping for platex."
   :group 'auctex-latexmk)
 
+(defcustom auctex-latexmk-inherit-TeX-PDF-mode nil
+  "If non-nil add -pdf flag to latexmk when TeX-PDF-mode is active."
+  :group 'auctex-latexmk)
+
 (defun TeX-run-latexmk (name command file)
   (let ((TeX-sentinel-default-function 'Latexmk-sentinel)
         (pair (assq buffer-file-coding-system auctex-latexmk-encoding-alist)))
@@ -85,9 +89,16 @@
 ;;;###autoload
 (defun auctex-latexmk-setup ()
   "Add LatexMk command to TeX-command-list."
+  (add-to-list 'TeX-expand-list
+               '("%(-PDF)"
+                 (lambda ()
+                   (if (and (not TeX-Omega-mode)
+                            TeX-PDF-mode
+                            auctex-latexmk-inherit-TeX-PDF-mode)
+                       "-pdf" ""))))
   (setq-default TeX-command-list
                 (cons
-                 '("LatexMk" "latexmk %S%(mode) %t" TeX-run-latexmk nil
+                 '("LatexMk" "latexmk %(-PDF)%S%(mode) %t" TeX-run-latexmk nil
                    (plain-tex-mode latex-mode doctex-mode) :help "Run LatexMk")
                  TeX-command-list)
                 LaTeX-clean-intermediate-suffixes

--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -75,7 +75,7 @@
   :group 'auctex-latexmk)
 
 (defcustom auctex-latexmk-inherit-TeX-PDF-mode nil
-  "If non-nil add -pdf flag to latexmk when TeX-PDF-mode is active."
+  "If non-nil add -pdf flag to latexmk when `TeX-PDF-mode' is active."
   :group 'auctex-latexmk)
 
 (defun TeX-run-latexmk (name command file)


### PR DESCRIPTION
Requiring users to configure latexmk by writing a `.latexmkrc` file makes it difficult to automate installation and configuration of this package. This PR adds support for adding the `-pdf` option when `TeX-PDF-mode` is active. This produces less surprising and more useful results out of the box, and eliminates the need to create a `.latexmkrc` file in most cases.
