### PR TITLE
add space after -pdf option

### DIFF
--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -95,7 +95,7 @@
                    (if (and (not TeX-Omega-mode)
                             TeX-PDF-mode
                             auctex-latexmk-inherit-TeX-PDF-mode)
-                       "-pdf" ""))))
+                       "-pdf " ""))))
   (setq-default TeX-command-list
                 (cons
                  '("LatexMk" "latexmk %(-PDF)%S%(mode) %t" TeX-run-latexmk nil


### PR DESCRIPTION
My previous PR omitted a space after the `-pdf` option, so currently if both `TeX-source-correlate-mode` and `auctex-latexmk-inherit-TeX-PDF-mode` are true the command is formatted incorrectly as `latexmk -pdf--synctex=`. This PR adds a space after the `-pdf ` option to avoid this problem.