### PR TITLE
Add -file-line-error option to latexmk command

### DIFF
--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -98,7 +98,7 @@
                        "-pdf " ""))))
   (setq-default TeX-command-list
                 (cons
-                 '("LatexMk" "latexmk %(-PDF)%S%(mode) -file-line-error %t" TeX-run-latexmk nil
+                 '("LatexMk" "latexmk %(-PDF)%S%(mode) %(file-line-error) %t" TeX-run-latexmk nil
                    (plain-tex-mode latex-mode doctex-mode) :help "Run LatexMk")
                  TeX-command-list)
                 LaTeX-clean-intermediate-suffixes

--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -98,7 +98,7 @@
                        "-pdf " ""))))
   (setq-default TeX-command-list
                 (cons
-                 '("LatexMk" "latexmk %(-PDF)%S%(mode) %t" TeX-run-latexmk nil
+                 '("LatexMk" "latexmk %(-PDF)%S%(mode) -file-line-error %t" TeX-run-latexmk nil
                    (plain-tex-mode latex-mode doctex-mode) :help "Run LatexMk")
                  TeX-command-list)
                 LaTeX-clean-intermediate-suffixes


### PR DESCRIPTION
AucTeX error navigation relies on passing the `-file-line-error` option to (pdf)latex. Without it error navigation frequently breaks[1]

This PR adds the required option. 

[1] For example reports of problems without this option see http://tex.stackexchange.com/questions/124246/uninformative-error-message-when-using-auctex and http://news.gmane.org/gmane.emacs.auctex.general