### PR TITLE
Change (not TeX-Omega-mode) to (eq TeX-engine 'default)

### DIFF
--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -93,7 +93,7 @@
                '("%(-PDF)"
                  (lambda ()
                    (cond
-                    ((and (not TeX-Omega-mode)
+                    ((and (eq TeX-engine 'default)
                           TeX-PDF-mode
                           auctex-latexmk-inherit-TeX-PDF-mode)
                      "-pdf ")


### PR DESCRIPTION
This change makes `auctex-latexmk` use the `-pdf` parameter only with the `default` TeX engine, which is the only one for which it applies. This fixes some corner cases of XeTeX and LuaTeX support.