### PR TITLE
'tex-buf.el' is merged into 'tex.el' and no longer exists in auctex > 13.1

### DIFF
--- a/auctex-latexmk.el
+++ b/auctex-latexmk.el
@@ -54,7 +54,7 @@
 
 ;;; Code:
 
-(require 'tex-buf)
+(require 'tex)
 (require 'latex)
 
 (defgroup auctex-latexmk nil


### PR DESCRIPTION
fixing #39 